### PR TITLE
DRUPAL_INSTALL_PROFILE_BRANCH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ ENV DRUPAL_INSTALL_PROFILE standard
 # Example custom profile: pull it from git
 #ENV DRUPAL_INSTALL_PROFILE boran1
 #ENV DRUPAL_INSTALL_REPO https://github.com/Boran/drupal-profile1.git
+ENV DRUPAL_INSTALL_PROFILE_BRANCH master
 # During build test: copy in directly
 #ADD ./drupal-profile1      /var/www/html/profiles/boran1
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ Environment parameters, defaults are as follows, commented values are not set by
     #DRUPAL_MAKE_BRANCH master
     # Which will run:  drush make ${DRUPAL_MAKE_DIR}/${DRUPAL_MAKE_DIR}.make ${DRUPAL_DOCROOT}
     DRUPAL_INSTALL_PROFILE standard
-    #DRUPAL_INSTALL_REPO https://github.com/Boran/drupal-profile1.git
+    Specify the repo and the branch of the install profile:
+    # DRUPAL_INSTALL_REPO https://github.com/Boran/drupal-profile1.git
+    # DRUPAL_INSTALL_PROFILE_BRANCH master
 
     # Run a feature revert revert after installing, can be useful for default content
     #ENV DRUPAL_MAKE_FEATURE_REVERT 1

--- a/start.sh
+++ b/start.sh
@@ -103,13 +103,8 @@ if [ ! -f $www/sites/default/settings.php -a ! -f /drupal-db-pw.txt ]; then
       mv $www $www.$$ 2>/dev/null             # will be created new by drush make
       mkdir /opt/drush-make 2>/dev/null
       cd /opt/drush-make
-      if [[ ${DRUPAL_MAKE_BRANCH} ]]; then
-        echo "git clone -b ${DRUPAL_MAKE_BRANCH} -q ${DRUPAL_MAKE_REPO} ${DRUPAL_MAKE_DIR}"
-        git clone -b ${DRUPAL_MAKE_BRANCH} -q ${DRUPAL_MAKE_REPO} ${DRUPAL_MAKE_DIR}
-      else
-        echo "git clone -q ${DRUPAL_MAKE_REPO} ${DRUPAL_MAKE_DIR}"
-        git clone -q ${DRUPAL_MAKE_REPO} ${DRUPAL_MAKE_DIR}
-      fi
+      echo "git clone -b ${DRUPAL_MAKE_BRANCH} -q ${DRUPAL_MAKE_REPO} ${DRUPAL_MAKE_DIR}"
+      git clone -b ${DRUPAL_MAKE_BRANCH} -q ${DRUPAL_MAKE_REPO} ${DRUPAL_MAKE_DIR}
       #echo "make command: ${DRUPAL_MAKE_CMD}"
       #${DRUPAL_MAKE_CMD}
       drush make ${DRUPAL_MAKE_DIR}/${DRUPAL_MAKE_DIR}.make $www
@@ -164,14 +159,8 @@ if [ ! -f $www/sites/default/settings.php -a ! -f /drupal-db-pw.txt ]; then
       echo "45" > $buildstat
       cd $www/profiles 
       # todo: INSTALL_REPO: allow for private repos, https and authentication
-      if [[ ${DRUPAL_INSTALL_PROFILE_BRANCH} ]]; then
-        echo "git clone -b ${DRUPAL_INSTALL_PROFILE_BRANCH} -q ${DRUPAL_INSTALL_REPO} ${DRUPAL_INSTALL_PROFILE}"
-        git clone -b ${DRUPAL_INSTALL_PROFILE_BRANCH} -q ${DRUPAL_INSTALL_REPO} ${DRUPAL_INSTALL_PROFILE}
-      else
-        echo "git clone -q ${DRUPAL_INSTALL_REPO} ${DRUPAL_INSTALL_PROFILE}"
-        git clone -q ${DRUPAL_INSTALL_REPO} ${DRUPAL_INSTALL_PROFILE}
-      fi
-
+      echo "git clone -b ${DRUPAL_INSTALL_PROFILE_BRANCH} -q ${DRUPAL_INSTALL_REPO} ${DRUPAL_INSTALL_PROFILE}"
+      git clone -b ${DRUPAL_INSTALL_PROFILE_BRANCH} -q ${DRUPAL_INSTALL_REPO} ${DRUPAL_INSTALL_PROFILE}
     fi
 
     # - run the drupal installer 

--- a/start.sh
+++ b/start.sh
@@ -103,8 +103,13 @@ if [ ! -f $www/sites/default/settings.php -a ! -f /drupal-db-pw.txt ]; then
       mv $www $www.$$ 2>/dev/null             # will be created new by drush make
       mkdir /opt/drush-make 2>/dev/null
       cd /opt/drush-make
-      echo "git clone -q ${DRUPAL_MAKE_REPO} ${DRUPAL_MAKE_DIR}"
-      git clone -b ${DRUPAL_MAKE_BRANCH} -q ${DRUPAL_MAKE_REPO} ${DRUPAL_MAKE_DIR}
+      if [[ ${DRUPAL_MAKE_BRANCH} ]]
+        echo "git clone -b ${DRUPAL_MAKE_BRANCH} -q ${DRUPAL_MAKE_REPO} ${DRUPAL_MAKE_DIR}"
+        git clone -b ${DRUPAL_MAKE_BRANCH} -q ${DRUPAL_MAKE_REPO} ${DRUPAL_MAKE_DIR}
+      else
+        echo "git clone -q ${DRUPAL_MAKE_REPO} ${DRUPAL_MAKE_DIR}"
+        git clone -q ${DRUPAL_MAKE_REPO} ${DRUPAL_MAKE_DIR}
+      fi
       #echo "make command: ${DRUPAL_MAKE_CMD}"
       #${DRUPAL_MAKE_CMD}
       drush make ${DRUPAL_MAKE_DIR}/${DRUPAL_MAKE_DIR}.make $www

--- a/start.sh
+++ b/start.sh
@@ -103,7 +103,7 @@ if [ ! -f $www/sites/default/settings.php -a ! -f /drupal-db-pw.txt ]; then
       mv $www $www.$$ 2>/dev/null             # will be created new by drush make
       mkdir /opt/drush-make 2>/dev/null
       cd /opt/drush-make
-      if [[ ${DRUPAL_MAKE_BRANCH} ]]
+      if [[ ${DRUPAL_MAKE_BRANCH} ]]; then
         echo "git clone -b ${DRUPAL_MAKE_BRANCH} -q ${DRUPAL_MAKE_REPO} ${DRUPAL_MAKE_DIR}"
         git clone -b ${DRUPAL_MAKE_BRANCH} -q ${DRUPAL_MAKE_REPO} ${DRUPAL_MAKE_DIR}
       else

--- a/start.sh
+++ b/start.sh
@@ -159,8 +159,14 @@ if [ ! -f $www/sites/default/settings.php -a ! -f /drupal-db-pw.txt ]; then
       echo "45" > $buildstat
       cd $www/profiles 
       # todo: INSTALL_REPO: allow for private repos, https and authentication
-      echo "git clone -q ${DRUPAL_INSTALL_REPO} ${DRUPAL_INSTALL_PROFILE}"
-      git clone -q ${DRUPAL_INSTALL_REPO} ${DRUPAL_INSTALL_PROFILE}
+      if [[ ${DRUPAL_INSTALL_PROFILE_BRANCH} ]]; then
+        echo "git clone -b ${DRUPAL_INSTALL_PROFILE_BRANCH} -q ${DRUPAL_INSTALL_REPO} ${DRUPAL_INSTALL_PROFILE}"
+        git clone -b ${DRUPAL_INSTALL_PROFILE_BRANCH} -q ${DRUPAL_INSTALL_REPO} ${DRUPAL_INSTALL_PROFILE}
+      else
+        echo "git clone -q ${DRUPAL_INSTALL_REPO} ${DRUPAL_INSTALL_PROFILE}"
+        git clone -q ${DRUPAL_INSTALL_REPO} ${DRUPAL_INSTALL_PROFILE}
+      fi
+
     fi
 
     # - run the drupal installer 


### PR DESCRIPTION
With this param a developer can test the installation profile specifying the working on branch.
It may not has sense with the forking workflow, but it has a lot with the branching workflow.
Also if it is not set, it is not used.